### PR TITLE
Feat: Add support for nuget based packages.config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,6 +130,7 @@ fn main() {
             ("pom.xml", PackageEcosystem::Maven),
             (".terraform.lock.hcl", PackageEcosystem::Terraform),
             // ("pubspec.yaml", PackageEcosystem::Pub),
+            ("packages.config", PackageEcosystem::Nuget),
             ("*.csproj", PackageEcosystem::Nuget), // TODO: make this work
         ]
         .map(|p| (p.0.to_string(), p.1)),


### PR DESCRIPTION
Why do we need this change?
=======================
Nuget supports multiple types and [packages.config](https://learn.microsoft.com/en-us/nuget/reference/packages-config) is another that some projects might leverage. So enable support for it

What effects does this change have?
=======================
* Add's packages.config as a nuget type that will be scanned/read and included in the checks