### PR TITLE
feat: support globs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +159,7 @@ dependencies = [
  "clap-verbosity-flag",
  "dependabot-config",
  "env_logger",
+ "globset",
  "itertools",
  "log",
  "tempfile",
@@ -216,6 +227,19 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4.5.40", features = ["derive"] }
 walkdir = { version = "2.3" }
 dependabot-config = "0.3"
 env_logger = "0.11"
+globset = "0.4.16"
 itertools = "0.14.0"
 log = "0.4"
 clap-verbosity-flag = "3.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,90 @@
 use clap_verbosity_flag::{InfoLevel, Verbosity};
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use log::{debug, error, info, warn};
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fs::{self},
     path::{Path, MAIN_SEPARATOR},
+    sync::LazyLock,
 };
 
 use clap::Parser;
 use dependabot_config::v2::{Dependabot, PackageEcosystem, Schedule, Update};
 use itertools::Itertools;
 use walkdir::{DirEntry, WalkDir};
+use PackageEcosystem::{
+    Bundler, Cargo, Composer, Docker, Elm, GithubActions, Gitsubmodule, Gomod, Gradle, Hex, Maven,
+    Npm, Nuget, Pip, Pub, Swift, Terraform,
+};
+
+static ECOSYSTEMS: LazyLock<HashMap<PackageEcosystem, GlobSet>> = LazyLock::new(|| {
+    HashMap::from([
+        (Bundler, patterns_to_globset(&PATTERNS_BUNDLER)),
+        (Cargo, patterns_to_globset(&PATTERNS_CARGO)),
+        (Composer, patterns_to_globset(&PATTERNS_COMPOSER)),
+        (Docker, patterns_to_globset(&PATTERNS_DOCKER)),
+        (Hex, patterns_to_globset(&PATTERNS_HEX)),
+        (Elm, patterns_to_globset(&PATTERNS_ELM)),
+        (Gitsubmodule, patterns_to_globset(&PATTERNS_GITSUBMODULES)),
+        (GithubActions, patterns_to_globset(&PATTERNS_GITHUBACTIONS)),
+        (Gomod, patterns_to_globset(&PATTERNS_GOMOD)),
+        (Gradle, patterns_to_globset(&PATTERNS_GRADLE)),
+        (Maven, patterns_to_globset(&PATTERNS_MAVEN)),
+        (Npm, patterns_to_globset(&PATTERNS_NPM)),
+        (Nuget, patterns_to_globset(&PATTERNS_NUGET)),
+        (Pip, patterns_to_globset(&PATTERNS_PIP)),
+        (Pub, patterns_to_globset(&PATTERNS_PUB)),
+        (Swift, patterns_to_globset(&PATTERNS_SWIFT)),
+        (Terraform, patterns_to_globset(&PATTERNS_TERRAFORM)),
+    ])
+});
+
+// Globs are defined in each FileFetcher class:
+// https://github.com/dependabot/dependabot-core/blob/HEAD/helm/lib/dependabot/helm/file_fetcher.rb#L9
+const PATTERNS_BUNDLER: [&str; 1] = ["Gemfile{,.lock}"];
+const PATTERNS_CARGO: [&str; 1] = ["Cargo.{toml,lock}"];
+const PATTERNS_COMPOSER: [&str; 1] = ["composer.{json,lock}"];
+const PATTERNS_DOCKER: [&str; 2] = ["*Dockerfile*", "*docker-compose*.y{,a}ml"];
+const PATTERNS_ELM: [&str; 1] = ["elm.json"];
+const PATTERNS_GITSUBMODULES: [&str; 1] = [".gitmodules"];
+const PATTERNS_GITHUBACTIONS: [&str; 1] = [".github/workflows/*.y{,a}ml"]; // path separators!
+const PATTERNS_GOMOD: [&str; 1] = ["go.{mod,sum}"];
+const PATTERNS_GRADLE: [&str; 3] = [
+    "build.gradle{,.kts}",
+    "gradle.build", // (older versions)
+    "settings.gradle",
+];
+#[allow(dead_code)]
+const PATTERNS_HELM: [&str; 1] = [
+    // "*.y{,a}ml", // doesn't really make sense to allow any YAML file
+    "Chart.lock",
+];
+const PATTERNS_MAVEN: [&str; 1] = ["pom.xml"];
+const PATTERNS_HEX: [&str; 1] = ["mix.{exs,lock}"]; // Elixir
+const PATTERNS_NPM: [&str; 3] = [
+    "package{,-lock}.json",
+    "{bun,deno,yarn}.lock",
+    "pnpm-lock.yaml",
+];
+const PATTERNS_NUGET: [&str; 3] = [
+    "*.csproj",
+    "project.json",    // (older .NET Core projects)
+    "packages.config", // (legacy NuGet projects)
+];
+const PATTERNS_PIP: [&str; 5] = [
+    "pyproject.toml",
+    "setup.{cfg,py}",
+    "requirements*.{in,txt}",
+    "{poetry,uv}.lock",
+    "Pipfile{,.lock}",
+];
+const PATTERNS_PUB: [&str; 1] = ["pubspec.{yaml,lock}"]; // Dart
+const PATTERNS_SWIFT: [&str; 1] = ["Package.{swift,resolved}"];
+const PATTERNS_TERRAFORM: [&str; 3] = [
+    "{main,variables}.tf",
+    "terraform.tfstate",
+    ".terraform.lock.hcl", // hidden file!
+];
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -21,11 +96,34 @@ struct Cli {
     verbose: Verbosity<InfoLevel>,
 }
 
-fn is_target(mapping: &HashMap<String, PackageEcosystem>, entry: &DirEntry) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .is_some_and(|s| mapping.contains_key(&s.to_string()))
+fn find_ecosystem<P: AsRef<Path> + ?Sized>(path: &P, root: &String) -> Option<PackageEcosystem> {
+    let filename = path.as_ref().file_name()?;
+    for (ecosystem, globset) in ECOSYSTEMS.iter() {
+        if ecosystem == &GithubActions {
+            if matches!(path.as_ref().strip_prefix(root), Ok(sub) if globset.is_match(sub)) {
+                return Some(*ecosystem);
+            }
+        } else if globset.is_match(filename) {
+            return Some(*ecosystem);
+        }
+    }
+    None
+}
+
+fn patterns_to_globset(x: &[&str]) -> GlobSet {
+    let mut npm = GlobSetBuilder::new();
+    x.iter()
+        .map(|p| {
+            GlobBuilder::new(p)
+                .empty_alternates(true)
+                .build()
+                .ok()
+                .unwrap()
+        })
+        .for_each(|g| {
+            npm.add(g);
+        });
+    npm.build().unwrap()
 }
 
 fn is_ignored(ignored_dirs: &HashSet<String>, entry: &DirEntry) -> bool {
@@ -49,21 +147,15 @@ struct EcosystemPath {
     path: String,
 }
 
-fn find_targets(
-    mapping: HashMap<String, PackageEcosystem>,
-    ignored_dirs: HashSet<String>,
-    walk: WalkDir,
-    root: String,
-) -> Vec<FoundTarget> {
+fn find_targets(ignored_dirs: HashSet<String>, walk: WalkDir, root: String) -> Vec<FoundTarget> {
     let grouped = walk
         .follow_links(true)
         .into_iter()
         .filter_entry(|entry| !is_ignored(&ignored_dirs, entry))
         .filter_map(|entry| entry.ok())
-        .filter(|entry| is_target(&mapping, entry))
-        .map(|entry| {
-            let file_name = entry.file_name().to_str().map(String::from).unwrap();
-            let ecosystem = *mapping.get(&file_name).unwrap();
+        .filter_map(|entry| {
+            let ecosystem = find_ecosystem(entry.path(), &root)?; // Skip unknown paths
+            let file_name = entry.file_name().to_str().map(String::from)?;
             let path = entry
                 .path()
                 .to_path_buf()
@@ -83,7 +175,7 @@ fn find_targets(
                     }
                 })
                 .expect("should resolve parent");
-            (EcosystemPath { ecosystem, path }, file_name)
+            Some((EcosystemPath { ecosystem, path }, file_name))
         })
         .into_group_map_by(|a| a.0.clone());
     let mut found = Vec::new();
@@ -133,44 +225,8 @@ fn main() {
     let ignored_dirs = HashSet::from([".git", "target", "node_modules"].map(|s| s.to_string()));
     debug!("Ignoring {:?}", &ignored_dirs);
 
-    let mapping = HashMap::from(
-        [
-            ("package.json", PackageEcosystem::Npm),
-            ("package-lock.json", PackageEcosystem::Npm),
-            ("yarn.lock", PackageEcosystem::Npm),
-            ("Dockerfile", PackageEcosystem::Docker),
-            ("Cargo.toml", PackageEcosystem::Cargo),
-            ("requirements.in", PackageEcosystem::Pip),
-            ("requirements.txt", PackageEcosystem::Pip),
-            ("pyproject.toml", PackageEcosystem::Pip),
-            ("poetry.lock", PackageEcosystem::Pip),
-            ("Pipfile", PackageEcosystem::Pip),
-            ("Pipfile.lock", PackageEcosystem::Pip),
-            ("setup.py", PackageEcosystem::Pip),
-            ("Gemfile.lock", PackageEcosystem::Bundler),
-            ("Gemfile", PackageEcosystem::Bundler),
-            ("composer.json", PackageEcosystem::Composer),
-            ("composer.lock", PackageEcosystem::Composer),
-            ("mix.exs", PackageEcosystem::Hex),
-            ("mix.lock", PackageEcosystem::Hex),
-            ("build.gradle", PackageEcosystem::Gradle),
-            ("build.gradle.kts", PackageEcosystem::Gradle),
-            ("pom.xml", PackageEcosystem::Maven),
-            (".terraform.lock.hcl", PackageEcosystem::Terraform),
-            // ("pubspec.yaml", PackageEcosystem::Pub),
-            ("packages.config", PackageEcosystem::Nuget),
-            ("*.csproj", PackageEcosystem::Nuget), // TODO: make this work
-        ]
-        .map(|p| (p.0.to_string(), p.1)),
-    );
-
     let walk_dir = WalkDir::new(scanned_root);
-    let found = find_targets(
-        mapping,
-        ignored_dirs,
-        walk_dir,
-        scanned_directory.clone().unwrap(),
-    );
+    let found = find_targets(ignored_dirs, walk_dir, scanned_directory.clone().unwrap());
 
     if found.is_empty() {
         info!("Found no targets.");
@@ -231,9 +287,12 @@ fn found_values(found: &[FoundTarget]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::{find_targets, found_managers, found_values, is_ignored};
-    use dependabot_config::v2::PackageEcosystem::{Cargo, Npm};
-    use std::collections::{HashMap, HashSet};
+    use crate::{find_ecosystem, find_targets, found_managers, found_values, is_ignored};
+    use dependabot_config::v2::PackageEcosystem::{
+        Bundler, Cargo, Composer, Docker, Elm, GithubActions, Gitsubmodule, Gomod, Gradle, Hex,
+        Maven, Npm, Nuget, Pip, Pub, Swift, Terraform,
+    };
+    use std::collections::HashSet;
     use std::fs;
     use tempfile::tempdir;
     use walkdir::WalkDir;
@@ -251,19 +310,20 @@ mod tests {
 
     #[test]
     fn deduplication_and_sorting_test() {
-        let mapping = HashMap::from([
-            ("package.json".into(), Npm),
-            ("package-lock.json".into(), Npm),
-            ("Cargo.toml".into(), Cargo),
-        ]);
-
+        let files = [
+            "package.json",
+            "package-lock.json",
+            "Cargo.toml",
+            ".github/workflows/ci.yml",
+        ];
         let tmpdir = tempdir().expect("Couldn't create temp dir");
-        mapping
-            .keys()
-            .for_each(|f| fs::write(tmpdir.path().join(f), "").expect("Couldn't create file"));
+        files.iter().for_each(|f| {
+            let path = tmpdir.path().join(f);
+            fs::create_dir_all(&path.parent().expect("parent")).expect("created subdirs");
+            fs::write(&path, "").expect("Couldn't create file")
+        });
 
         let found = find_targets(
-            mapping,
             HashSet::new(),
             WalkDir::new(tmpdir.path()),
             tmpdir.path().to_str().unwrap().to_string(),
@@ -273,10 +333,61 @@ mod tests {
         let values = found_values(&found);
         assert_eq!(
             (
-                "cargo, npm",
-                "cargo: / (Cargo.toml)\nnpm: / (package-lock.json, package.json)"
+                "cargo, github-actions, npm",
+                "cargo: / (Cargo.toml)\ngithub-actions: / (ci.yml)\nnpm: / (package-lock.json, package.json)"
             ),
             (managers.as_str(), values.as_str())
         );
+    }
+
+    #[test]
+    fn find_ecosystem_test() {
+        #[rustfmt::skip]
+        let files = [
+            "unknown",
+            "a/Gemfile", "Gemfile.lock",
+            "a/Cargo.toml", "Cargo.lock",
+            "a/composer.json", "composer.lock",
+            "a/Dockerfile", "Dockerfile.alpine", "local.Dockerfile", "myDockerfile.alpine", "docker-compose.yml", "mydocker-compose.yml", "docker-compose-prod.yaml",
+            "a/elm.json",
+            ".gitmodules",
+            ".github/workflows/ci.yml",
+            "a/go.mod", "go.sum",
+            "a/build.gradle", "build.gradle.kts", "gradle.build", "settings.gradle",
+            "a/pom.xml",
+            "a/mix.exs", "mix.lock",
+            "a/package.json", "package-lock.json", "bun.lock", "deno.lock", "yarn.lock", "pnpm-lock.yaml",
+            "a/b.csproj", "project.json", "packages.config",
+            "a/pyproject.toml", "setup.cfg", "setup.py", "requirements.in", "requirements-dev.in", "requirements.txt", "requirements-prod.txt", "poetry.lock", "uv.lock", "Pipfile", "Pipfile.lock",
+            "a/pubspec.yaml", "pubspec.lock",
+            "a/Package.swift", "Package.resolved",
+            "a/main.tf", "variables.tf", "terraform.tfstate", ".terraform.lock.hcl",
+        ];
+        #[rustfmt::skip]
+        let expected = vec![
+            None,
+            Some(Bundler), Some(Bundler),
+            Some(Cargo), Some(Cargo),
+            Some(Composer), Some(Composer),
+            Some(Docker), Some(Docker), Some(Docker), Some(Docker), Some(Docker), Some(Docker), Some(Docker),
+            Some(Elm),
+            Some(Gitsubmodule),
+            Some(GithubActions),
+            Some(Gomod), Some(Gomod),
+            Some(Gradle), Some(Gradle), Some(Gradle), Some(Gradle),
+            Some(Maven),
+            Some(Hex), Some(Hex),
+            Some(Npm), Some(Npm), Some(Npm), Some(Npm), Some(Npm), Some(Npm),
+            Some(Nuget), Some(Nuget), Some(Nuget),
+            Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip),
+            Some(Pub), Some(Pub),
+            Some(Swift), Some(Swift),
+            Some(Terraform), Some(Terraform), Some(Terraform), Some(Terraform)
+        ];
+        let results: Vec<_> = files
+            .into_iter()
+            .map(|f| find_ecosystem(f, &String::new()))
+            .collect();
+        assert_eq!(results, expected);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,11 +61,7 @@ const PATTERNS_HELM: [&str; 1] = [
 ];
 const PATTERNS_MAVEN: [&str; 1] = ["pom.xml"];
 const PATTERNS_HEX: [&str; 1] = ["mix.{exs,lock}"]; // Elixir
-const PATTERNS_NPM: [&str; 3] = [
-    "package{,-lock}.json",
-    "{bun,deno,yarn}.lock",
-    "pnpm-lock.yaml",
-];
+const PATTERNS_NPM: [&str; 3] = ["package{,-lock}.json", "{deno,yarn}.lock", "pnpm-lock.yaml"];
 const PATTERNS_NUGET: [&str; 3] = [
     "*.csproj",
     "project.json",    // (older .NET Core projects)
@@ -75,7 +71,7 @@ const PATTERNS_PIP: [&str; 5] = [
     "pyproject.toml",
     "setup.{cfg,py}",
     "requirements*.{in,txt}",
-    "{poetry,uv}.lock",
+    "poetry.lock",
     "Pipfile{,.lock}",
 ];
 const PATTERNS_PUB: [&str; 1] = ["pubspec.{yaml,lock}"]; // Dart
@@ -357,9 +353,9 @@ mod tests {
             "a/build.gradle", "build.gradle.kts", "gradle.build", "settings.gradle",
             "a/pom.xml",
             "a/mix.exs", "mix.lock",
-            "a/package.json", "package-lock.json", "bun.lock", "deno.lock", "yarn.lock", "pnpm-lock.yaml",
+            "a/package.json", "package-lock.json", "deno.lock", "yarn.lock", "pnpm-lock.yaml",
             "a/b.csproj", "project.json", "packages.config",
-            "a/pyproject.toml", "setup.cfg", "setup.py", "requirements.in", "requirements-dev.in", "requirements.txt", "requirements-prod.txt", "poetry.lock", "uv.lock", "Pipfile", "Pipfile.lock",
+            "a/pyproject.toml", "setup.cfg", "setup.py", "requirements.in", "requirements-dev.in", "requirements.txt", "requirements-prod.txt", "poetry.lock", "Pipfile", "Pipfile.lock",
             "a/pubspec.yaml", "pubspec.lock",
             "a/Package.swift", "Package.resolved",
             "a/main.tf", "variables.tf", "terraform.tfstate", ".terraform.lock.hcl",
@@ -378,9 +374,9 @@ mod tests {
             Some(Gradle), Some(Gradle), Some(Gradle), Some(Gradle),
             Some(Maven),
             Some(Hex), Some(Hex),
-            Some(Npm), Some(Npm), Some(Npm), Some(Npm), Some(Npm), Some(Npm),
+            Some(Npm), Some(Npm), Some(Npm), Some(Npm), Some(Npm),
             Some(Nuget), Some(Nuget), Some(Nuget),
-            Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip),
+            Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip), Some(Pip),
             Some(Pub), Some(Pub),
             Some(Swift), Some(Swift),
             Some(Terraform), Some(Terraform), Some(Terraform), Some(Terraform)


### PR DESCRIPTION
### Features
- Support all package managers which dependabot-config allows

### TODO
- Support case-insensitive patterns (like Dockerfile) or when running on case-insensitive filesystems
- Double-check if some patterns are missing (just add to `find_ecosystem_test()` first)